### PR TITLE
Force a carriage return after the last task is processed.

### DIFF
--- a/canvas_to_clickup.rb
+++ b/canvas_to_clickup.rb
@@ -329,7 +329,7 @@ all_assignments.each do |course_name, assignments|
   # puts response
 end
 
-print_to_console "\rFinished processing #{index} tasks."
+print_to_console "\n\rFinished processing #{index} tasks."
 puts "\n"
 
 puts "Created: #{created}"

--- a/canvas_to_clickup.rb
+++ b/canvas_to_clickup.rb
@@ -329,7 +329,7 @@ all_assignments.each do |course_name, assignments|
   # puts response
 end
 
-print_to_console "\n\rFinished processing #{index} tasks."
+print_to_console "\nFinished processing #{index} tasks."
 puts "\n"
 
 puts "Created: #{created}"


### PR DESCRIPTION
How it would output before:
<img width="728" alt="image" src="https://user-images.githubusercontent.com/11000195/186748815-d0b5d19e-2a70-4b90-b8b0-6e95c66af0bf.png">

How it outputs now:
<img width="340" alt="image" src="https://user-images.githubusercontent.com/11000195/186748900-1fe45a2a-02fa-4973-b6b4-30a22db318df.png">
